### PR TITLE
fix(backend): bump eneo-sundsvall to 1.2 and enforce single conversation target

### DIFF
--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -6,6 +6,6 @@ export const APIS = [
   },
   {
     name: 'eneo-sundsvall',
-    version: '1.0',
+    version: '1.2',
   },
 ] as const;

--- a/backend/src/controllers/conversation.controller.ts
+++ b/backend/src/controllers/conversation.controller.ts
@@ -36,7 +36,11 @@ export class ConversationController {
 
     const url = `${this.basePath}/conversations/`;
     const responseType = body?.stream ? 'stream' : 'json';
-    const data: ConversationRequest = body;
+    // Eneo 1.2 requires exactly one of session_id / assistant_id / group_chat_id.
+    // When continuing a session, session_id wins and the others must be dropped.
+    const data: ConversationRequest = body.session_id
+      ? { ...body, assistant_id: undefined, group_chat_id: undefined }
+      : body;
     try {
       if (responseType === 'json') {
         const res = await this.apiService.post<AskResponseInterface, ConversationRequest>(url, data, {


### PR DESCRIPTION
## Summary
- Bumps `eneo-sundsvall` API version from `1.0` to `1.2`.
- In `ConversationController.newConversation`, when `body.session_id` is set we now strip `assistant_id` and `group_chat_id` from the outgoing request. Eneo 1.2 rejects payloads containing more than one of `session_id` / `assistant_id` / `group_chat_id`.
